### PR TITLE
Use regex instead of a string

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -30,8 +30,8 @@ module.exports = async message => {
           if(!message.content.startsWith(prefix + "settings")) return message.channel.send(`Please run ${alt.prefix}settings to set up the bot first!`)
         }
       }
-      let command = message.content.split(' ')[0].slice(prefix.length);
-      let params = message.content.split(' ').slice(1);
+      let params = message.content.slice(prefix.length).split(/\s+/);
+      let command = params.shift();
       let perms = client.elevation(message);
       let cmd;
       if (client.commands.has(command)) {


### PR DESCRIPTION
With this regex, you can parse arguments correctly. If I did `!help arg            arg                           arg` it would've given me over 10 arguments, not 3. I have used \s+ as the regex to match all whitespace between arguments, and I have also used .shift() for more concise code.